### PR TITLE
terraform-script: Extend inventory file with ansible connection variables

### DIFF
--- a/ansible/terraform.py
+++ b/ansible/terraform.py
@@ -413,12 +413,9 @@ def _backup_ansible(inventory):
     text += '# For emergency use when Consul fails\n'
     text += '[all]\n'
     for hostname, host in sorted(inventory.hosts.items()):
-        text += (
-            '{0} hostname={0} ansible_host={1} '
-        ).format(hostname, host.host_vars['ansible_host']) + (
-            'env={env} stage={stage} data_center={data_center} '+
-            'region={region} dns_entry={dns_entry}\n'
-        ).format(**host.host_vars)
+        host_vars = {k: v for k, v in host.host_vars.items() if k != 'hostname'}
+        vars_text = " ".join(f"{k}={v}" for k,v in host_vars.items())
+        text += f"{hostname} {vars_text}\n"
     text += '\n'
     for name, hosts in sorted(inventory.groups.items()):
         if name in ['_meta', 'all']:


### PR DESCRIPTION
Extend terraform.py script to populate inventory file with variables `ansible_become_method`, `ansible_become_user` and `ansible_shell_type`. The values for these variables are fetched from terraform state if present, otherwise the defaults are set.

Referenced issue: https://github.com/status-im/infra-template/issues/10