### PR TITLE
flake: fix two versions of python in shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,8 +19,8 @@
         pkgs = pkgsFor.${system};
       in {
         default = let
-          pythonPkgs = pkgs.python311.withPackages (
-            _: with (pkgs.python311Packages); [
+          pythonPkgs = pkgs.python3.withPackages (
+            _: with (pkgs.python3Packages); [
               ipython pyyaml jinja2 PyGithub
               pyopenssl cryptography
               hvac


### PR DESCRIPTION
Fixes:
```
Traceback (most recent call last):
  File "/home/jakubgs/work/infra-eth2/ansible/lookup_plugins/vault.py", line 6, in <module>
    import hvac
ModuleNotFoundError: No module named 'hvac'
```
Before.
```
 > echo $PATH | tr ':' '\n' | grep python3-
/nix/store/04gg5w1s662l329a8kh9xcwyp0k64v5a-python3-3.12.4/bin
/nix/store/38nsff4vmhjmvfsi864yb23y9rk9gw5c-python3-3.11.9-env/bin
```
After the fix.
```
 > echo $PATH | tr ':' '\n' | grep python3-
/nix/store/04gg5w1s662l329a8kh9xcwyp0k64v5a-python3-3.12.4/bin
/nix/store/pxgdzih20d368bx0h0kzyln5hl5cjgyl-python3-3.12.4-env/bin
```
Caused by upgrade to `unstable` without checking default Python version.