### PR TITLE
ansible: provide passwords for users from Vault

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 forks = 30
 timeout = 30
+remote_user = admin
 inventory = ./ansible/terraform.py
 callback_plugins = ./ansible/callback_plugins
 lookup_plugins = ./ansible/lookup_plugins

--- a/ansible/filter_plugins/get_user_passwords.py
+++ b/ansible/filter_plugins/get_user_passwords.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+from ansible.errors import AnsibleError
+from ansible.plugins.loader import lookup_loader
+
+class FilterModule(object):
+    def filters(self):
+        return { 'get_user_passwords': self.get_user_passwords }
+
+    def get_user_passwords(self, users):
+        vault = lookup_loader.get('vault')
+        variables = { 'env': 'all', 'stage': 'all' }
+        get_pass = lambda name: vault.run(terms=["users"], field=name, variables=variables)
+        rval = {}
+        for user in users:
+            try:
+                rval[user['name']] = get_pass(user['name'])
+            except AnsibleError as err:
+                continue # Allow for users without passwords
+        return rval

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,5 +1,6 @@
 ---
 # Passwords
+ansible_become_password: '{{lookup("passwordstore", "hosts/admin-pass")}}'
 bootstrap__admin_pass: '{{lookup("vault", "users", field="admin", stage="all", env="all")}}'
 bootstrap__root_pass:  '{{lookup("vault", "users", field="root",  stage="all", env="all")}}'
 bootstrap__active_users_passwords: '{{ bootstrap__active_users | get_user_passwords }}'

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,6 +1,8 @@
 ---
-# Root password
-bootstrap__root_pass:               '{{lookup("vault", "config",            field="root-pass",             stage="all", env="all")}}'
+# Passwords
+bootstrap__admin_pass: '{{lookup("vault", "users", field="admin", stage="all", env="all")}}'
+bootstrap__root_pass:  '{{lookup("vault", "users", field="root",  stage="all", env="all")}}'
+bootstrap__active_users_passwords: '{{ bootstrap__active_users | get_user_passwords }}'
 # Consul
 bootstrap__consul_encryption_key:   '{{lookup("vault", "config",            field="consul-encryption-key", stage="all", env="all")}}'
 bootstarp__consul_agent_acl_token:  '{{lookup("vault", "consul/acl-tokens", field="agent-default",         stage="all", env="all")}}'
@@ -20,4 +22,3 @@ wazuh_root_ca:                      '{{ lookup("vault", "root-ca",        field=
 bootstrap__vault_ca_cert:           '{{ lookup("passwordstore", "services/vault/certs/root-ca/cert returnall=true")}}'
 bootstrap__vault_client_cert:       '{{ lookup("passwordstore", "services/vault/certs/client-host/cert returnall=true")}}'
 bootstrap__vault_client_key:        '{{ lookup("passwordstore", "services/vault/certs/client-host/privkey returnall=true")}}'
-


### PR DESCRIPTION
Created a filter plugin because this fails:
```lua
{{ bootstrap__active_users | map(attribute="name") | map("vault", "users", stage="all", env="all") }}
```
Since Ansible map function can't use lookup plugins.

Required for:
- https://github.com/status-im/infra-role-bootstrap-linux/pull/63