### PR TITLE
ansible/roles.py: use fetch to detect missing commits

### DIFF
--- a/ansible/roles.py
+++ b/ansible/roles.py
@@ -273,7 +273,7 @@ class Role:
 
     @State.update(success=State.UPDATED, failure=State.WRONG_VERSION)
     def pull(self):
-        self._git('remote', 'update', self.best_remote())
+        self.fetch()
         status = self._git('status', '--untracked-files=no')
 
         if 'branch is up to date' in status:


### PR DESCRIPTION
For some reason using `git remote update` doesn't guarantee it.