### PR TITLE
envrc: create secrets dir under user temp dir

### DIFF
--- a/.envrc.secrets
+++ b/.envrc.secrets
@@ -1,8 +1,28 @@
-export VAULT_CACERT=./ansible/files/vault-ca.crt
-export VAULT_CLIENT_CERT=./ansible/files/vault-client-user.crt
-export VAULT_CLIENT_KEY=./ansible/files/vault-client-user.key
+# vim: ft=bash
+
+# We re-use the secrets folder across repos to limit load time.
+export SECRETS_DIR_NAME='ift-infra-secrets'
+# Fallback to /tmp is mostly for the sake of poor MacOS users.
+export SECRETS_DIR="${TMPDIR:-${XDG_RUNTIME_DIR:-/tmp}}/${SECRETS_DIR_NAME}"
+mkdir -p "${SECRETS_DIR}"
+
+function pass_to_file() {
+    umask 277
+    local SECRET_PATH="${SECRETS_DIR}/${2}"
+    [[ -r "${SECRET_PATH}" ]] || pass "${1}" > "${SECRET_PATH}"
+    echo "${SECRET_PATH}"
+}
+
 export VAULT_ADDR=https://vault-api.infra.status.im:8200
+export VAULT_CACERT=$(pass_to_file       services/vault/certs/ca-chain            vault-ca.crt)
+export VAULT_CLIENT_CERT=$(pass_to_file  services/vault/certs/client-user/cert    vault-client-user.crt)
+export VAULT_CLIENT_KEY=$(pass_to_file   services/vault/certs/client-user/privkey vault-client-user.key)
+
 export CONSUL_HTTP_TOKEN=$(pass services/consul/tokens/terraform)
+export CONSUL_CACERT=$(pass_to_file      services/consul/ca-crt     consul-ca.crt)
+export CONSUL_CLIENT_CERT=$(pass_to_file services/consul/client-crt consul-client.crt)
+export CONSUL_CLIENT_KEY=$(pass_to_file  services/consul/client-key consul-client.key)
+
 # Provide a script in your PATH matching this name to load the token.
 if command -v vault_token_provider >/dev/null; then
     export VAULT_TOKEN=$(vault_token_provider)

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,8 @@
 *.retry
 .direnv/
 
-ansible/files/*
 __pycache__
+
+# FIXME: Remove once all old cert files are cleaned up.
+ansible/files/*.crt
+ansible/files/*.key

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PROVISIONER_ARCHIVE = $(PROVISIONER_NAME)-$(ARCH)-$(PROVISIONER_VERSION)
 PROVISIONER_URL = https://github.com/status-im/terraform-provisioner-ansible/releases/download/$(PROVISIONER_VERSION)/$(PROVISIONER_ARCHIVE)
 PROVISIONER_PATH = $(TF_PLUGINS_DIR)/$(PROVISIONER_NAME)
 
-all: roles-install install-provisioner secrets init-terraform checks
+all: roles-install install-provisioner init-terraform checks
 	@echo "Success!"
 
 roles-install:
@@ -48,12 +48,8 @@ install-provisioner: $(PROVISIONER_PATH)
 		|| rm -v $(PROVISIONER_PATH)
 
 secrets:
-	pass services/consul/ca-crt > ansible/files/consul-ca.crt
-	pass services/consul/client-crt > ansible/files/consul-client.crt
-	pass services/consul/client-key > ansible/files/consul-client.key
-	pass services/vault/certs/ca-chain > ansible/files/vault-ca.crt
-	pass services/vault/certs/client-user/cert > ansible/files/vault-client-user.crt
-	pass services/vault/certs/client-user/privkey > ansible/files/vault-client-user.key
+	rm -fr $(SECRETS_DIR)
+	direnv reload
 
 init-terraform: consul-check
 	terraform init -upgrade=true


### PR DESCRIPTION
We re-use the secrets folder across repos without cleanup because:

- This way we avoid the need to re-create the secrets files every time.
- Using cleanup methods like `trap` foes not work with `use flake`.
- Using detached process to catch shell exist freezes direnv source process.

But mostly to save time.

The path of making Vault lookup plugin load certs from env variables directly as explored but ended up in the same place of needing to create temporary files but in Python instead.

Main motivation for this change is avoiding feeding secrets to AI agents.

:warning: __WARNING:__ This PR does not clean up old secrets from existing repo checkouts!