### PR TITLE
switch from pass to gopass

### DIFF
--- a/.envrc.secrets
+++ b/.envrc.secrets
@@ -9,7 +9,7 @@ mkdir -p "${SECRETS_DIR}"
 function pass_to_file() {
     umask 277
     local SECRET_PATH="${SECRETS_DIR}/${2}"
-    [[ -r "${SECRET_PATH}" ]] || pass "${1}" > "${SECRET_PATH}"
+    [[ -r "${SECRET_PATH}" ]] || gopass "${1}" > "${SECRET_PATH}"
     echo "${SECRET_PATH}"
 }
 
@@ -18,7 +18,7 @@ export VAULT_CACERT=$(pass_to_file       services/vault/certs/ca-chain          
 export VAULT_CLIENT_CERT=$(pass_to_file  services/vault/certs/client-user/cert    vault-client-user.crt)
 export VAULT_CLIENT_KEY=$(pass_to_file   services/vault/certs/client-user/privkey vault-client-user.key)
 
-export CONSUL_HTTP_TOKEN=$(pass services/consul/tokens/terraform)
+export CONSUL_HTTP_TOKEN=$(gopass services/consul/tokens/terraform)
 export CONSUL_CACERT=$(pass_to_file      services/consul/ca-crt     consul-ca.crt)
 export CONSUL_CLIENT_CERT=$(pass_to_file services/consul/client-crt consul-client.crt)
 export CONSUL_CLIENT_KEY=$(pass_to_file  services/consul/client-key consul-client.key)

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,8 @@ direnv-check:
 	fi
 
 pass-check:
-	@pass git fetch -q
-	@pass git status | grep -q 'Your branch is up to date with' || \
+	@gopass --nosync git fetch -q > /dev/null
+	@gopass --nosync git status | grep -q 'Your branch is up to date with' || \
 		echo -e '$(YLW)WARNING: infra-pass is not up to date with its remote.$(RST)'
 
 checks: roles-check direnv-check consul-check vault-check pass-check

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -29,3 +29,6 @@ ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o ForwardAgent=yes -o Co
 [persistent_connection]
 command_timeout = 60
 connect_retry_timeout = 30
+
+[passwordstore_lookup]
+backend = gopass

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -60,7 +60,7 @@ ansible-playbook ansible/main.yml -e compose_recreate=always
 
 Secrets are stored and provided in three ways:
 
-* [password-store](https://www.passwordstore.org/) - Using [`passwordstore`](https://docs.ansible.com/ansible/latest/collections/community/general/passwordstore_lookup.html) plugin for core infra secrets.
+* [gopass](https://www.gopass.pw/) - Using [`passwordstore`](https://docs.ansible.com/ansible/latest/collections/community/general/passwordstore_lookup.html) plugin for core infra secrets.
 * [Vault](https://www.vaultproject.io/) - Using [`vault`](./lookup_plugins/vault.py) plugin for service secrets.
 
 Read [secrets management guide](https://docs.infra.status.im/guides/secret_management.html) for more details.

--- a/ansible/become_pass.sh
+++ b/ansible/become_pass.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 # Used via BECOME_PASSWORD_FILE to avoid re-evaluation on every task.
-pass hosts/admin-pass
+gopass hosts/admin-pass

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -12,9 +12,9 @@ bootstrap__consul_certs_ca_crt:               '{{lookup("vault", "consul/certs",
 bootstrap__consul_certs_client_crt:           '{{lookup("vault", "consul/certs",      field="client.pem",           env="all", stage="all")}}'
 bootstrap__consul_certs_client_key:           '{{lookup("vault", "consul/certs",      field="client-key.pem",       env="all", stage="all")}}'
 # Vault certificate
-bootstrap__vault_ca_cert:                     '{{ lookup("passwordstore", "services/vault/certs/ca-chain returnall=true")}}'
-bootstrap__vault_client_cert:                 '{{ lookup("passwordstore", "services/vault/certs/client-host/cert returnall=true")}}'
-bootstrap__vault_client_key:                  '{{ lookup("passwordstore", "services/vault/certs/client-host/privkey returnall=true")}}'
+bootstrap__vault_ca_cert:                     '{{ lookup("community.general.passwordstore", "services/vault/certs/ca-chain", returnall=true)}}'
+bootstrap__vault_client_cert:                 '{{ lookup("community.general.passwordstore", "services/vault/certs/client-host/cert", returnall=true)}}'
+bootstrap__vault_client_key:                  '{{ lookup("community.general.passwordstore", "services/vault/certs/client-host/privkey", returnall=true)}}'
 # SSHGuard
 bootstrap__sshguard_whitelist_extra:          ['{{lookup("vault", "sshguard/whitelist",    field="jakubgs-home", env="all", stage="all")}}']
 # Wireguard

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
             # infra
             terraform ansible_2_17 pythonPkgs
             # security
-            pass vault yubikey-manager pwgen
+            gopass vault yubikey-manager pwgen
             # cloud
             aliyun-cli awscli doctl google-cloud-sdk
             hcloud s3cmd scaleway-cli


### PR DESCRIPTION
Closes https://github.com/status-im/infra-template/issues/42

Ansible lookup plugin supports `gopass` with configuration:
https://docs.ansible.com/projects/ansible/latest/collections/community/general/passwordstore_lookup.html#parameter-backend

Terraform provider supports `gopass` without additional configuration:
https://github.com/camptocamp/terraform-provider-pass

Benefits of `gopass` compared to `password-store`:
- supports both gpg and age with ability to convert
- doesnt have macos slow `pass git` issues
- adds autosync, mounts
- more active code maintenance (`password-store` latest release Jun 2021, latest commit Jun 2025)