### PR TITLE
flake: support adding optional pkgs.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,11 @@
             ]
           );
         in pkgs.mkShellNoCC {
-          packages = with pkgs.buildPackages; [
+          packages = with pkgs.buildPackages; let
+            # Optional pkgs.nix for customizing repo dev shell.
+            extraPkgs = pkgs.lib.optionals (builtins.pathExists ./pkgs.nix)
+              (import ./pkgs.nix { inherit pkgs; });
+          in [
             # misc
             git openssh jq silver-searcher direnv
             # networking
@@ -34,7 +38,7 @@
             # cloud
             aliyun-cli awscli doctl google-cloud-sdk
             hcloud s3cmd scaleway-cli
-          ];
+          ] ++ extraPkgs;
 
           shellHook = ''
             make checks


### PR DESCRIPTION
This allows for expanding fleet shell with extra tools but allows to still copy `flake.nix` from infra-template repo without issues.

Example `pkgs.nix`:
```nix
{ pkgs }: with pkgs; [ sops yq ]
```