### PR TITLE
vault: put cache in SECRETS_DIR by default

### DIFF
--- a/.envrc.secrets
+++ b/.envrc.secrets
@@ -3,6 +3,7 @@
 # We re-use the secrets folder across repos to limit load time.
 export SECRETS_DIR_NAME='ift-infra-secrets'
 # Fallback to /tmp is mostly for the sake of poor MacOS users.
+# Also used by Vault lookup plugin cache file location.
 export SECRETS_DIR="${TMPDIR:-${XDG_RUNTIME_DIR:-/tmp}}/${SECRETS_DIR_NAME}"
 mkdir -p "${SECRETS_DIR}"
 

--- a/ansible/callback_plugins/vault_cache.py
+++ b/ansible/callback_plugins/vault_cache.py
@@ -1,5 +1,4 @@
-import os
-
+from os import path, listdir, makedirs, remove, getpid, environ
 from ansible.plugins.callback import CallbackBase
 from ansible.utils.display import Display
 
@@ -12,15 +11,15 @@ class CallbackModule(CallbackBase):
 
     def __init__(self):
         super(CallbackModule, self).__init__()
-        self.cache_dir = "./ansible/files/cache/vault"
-        self.cache_file = f"{self.cache_dir}/{os.getpid()}.cache"
+        self.cache_dir = environ.get('SECRETS_DIR', './ansible/files/cache')
+        self.cache_file = f"{self.cache_dir}/vault-lookup-{getpid()}.cache"
         self._create_cache_dir()
 
     def _create_cache_dir(self):
         """Creates the cache dir if it doesn't exist."""
         try:
-            if not os.path.exists(self.cache_dir):
-                os.makedirs(self.cache_dir)
+            if not path.exists(self.cache_dir):
+                makedirs(self.cache_dir)
                 display.v(f"Created cache directory: {self.cache_dir}")
         except Exception as e:
             display.error(f"Failed to create cache dir: {e}")
@@ -28,11 +27,11 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_stats(self, stats):
         """Called when the playbook ends, deletes all files in the cache directory."""
         try:
-            if os.path.exists(self.cache_dir):
-                for filename in os.listdir(self.cache_dir):
-                    file_path = os.path.join(self.cache_dir, filename)
+            if path.exists(self.cache_dir):
+                for filename in listdir(self.cache_dir):
+                    file_path = path.join(self.cache_dir, filename)
                     try:
-                        os.remove(file_path)
+                        remove(file_path)
                         display.v(f"Deleted cache file: {file_path}")
                     except Exception as e:
                         display.error(f"Failed to delete {file_path}: {e}")

--- a/ansible/lookup_plugins/vault.py
+++ b/ansible/lookup_plugins/vault.py
@@ -71,8 +71,10 @@ RETURN = """
     description:
       - Items for Hashicorp Vault
 """
+CACHE_DIR         = os.environ.get('SECRETS_DIR',       './ansible/files/cache')
 VAULT_CACERT      = os.environ.get('VAULT_CACERT',      './ansible/files/vault-ca.crt')
 VAULT_CLIENT_CERT = os.environ.get('VAULT_CLIENT_CERT', './ansible/files/vault-client-user.crt')
+VAULT_CLIENT_KEY  = os.environ.get('VAULT_CLIENT_KEY',  './ansible/files/vault-client-user.key')
 VAULT_CLIENT_KEY  = os.environ.get('VAULT_CLIENT_KEY',  './ansible/files/vault-client-user.key')
 
 LOG_PREFIX = "[lookup/vault]"
@@ -82,7 +84,7 @@ class LookupModule(LookupBase):
     def run(self, terms, field: str, variables=None, override: str = False, **kwargs):
         self.vault = hvac.Client(cert=(VAULT_CLIENT_CERT, VAULT_CLIENT_KEY),verify=VAULT_CACERT)
         parent_pid = os.getppid()
-        self.cache_file = f"./ansible/files/cache/vault/{parent_pid}.cache"
+        self.cache_file = f"{CACHE_DIR}/vault-lookup-{parent_pid}.cache"
         self.cache_encryption_key = base64.urlsafe_b64encode(hashlib.sha256(self.vault.token.encode()).digest())
         values = []
         env = kwargs.get("env", variables["env"])


### PR DESCRIPTION
I've observed cases where the Vault plugin cache directory stays after Ansible crashes or is stopped by user. Dir used by certificates is a good location for the cache that will be removed for sure since it's in `/run`.

Result:
```
 > ls -l $SECRETS_DIR
total 28
-r-------- 1 jakubgs jakubgs 1074 Jun 24 23:58 consul-ca.crt
-r-------- 1 jakubgs jakubgs  981 Jun 24 23:58 consul-client.crt
-r-------- 1 jakubgs jakubgs  227 Jun 24 23:58 consul-client.key
-r-------- 1 jakubgs jakubgs 4090 Jun 24 23:58 vault-ca.crt
-r-------- 1 jakubgs jakubgs 1728 Jun 24 23:58 vault-client-user.crt
-r-------- 1 jakubgs jakubgs 1704 Jun 24 23:58 vault-client-user.key
-rw-r--r-- 1 jakubgs jakubgs  312 Jun 25 13:47 vault-lookup-96935.cache
```