### PR TITLE
nix: ugrade from Ansible 2.17 to 2.18

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -15,6 +15,13 @@ stdout_callback = debug
 interpreter_python = auto_silent
 # https://github.com/ansible/ansible/issues/56930
 force_valid_group_names = ignore
+# Avoid hidden duplicate key bugs
+duplicate_dict_key = error
+# Enable all warnings
+deprecation_warnings = true
+action_warnings = true
+system_warnings = true
+allow_broken_conditionals = false
 
 [privilege_escalation]
 become = true

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
             # networking
             curl nmap nettools dnsutils
             # infra
-            terraform ansible_2_17 pythonPkgs
+            terraform ansible_2_18 pythonPkgs
             # security
             gopass vault yubikey-manager pwgen
             # cloud


### PR DESCRIPTION
Switching to `2.19` would require a lot of template and role changes. Using `2.18` will give us deprecation warnings about these changes first.

Enables all warnings to prepare for the 2.19 upgrade eventually.